### PR TITLE
Add script name configuration value loading from environment variables

### DIFF
--- a/emailusers.php
+++ b/emailusers.php
@@ -77,6 +77,16 @@ $pwp_html_footer = "</body></html>\n";
 
 $pwp_script_version = "1.3.0";
 
+function fpwp_getenv($name, $default) {
+  $env = getenv("PWP_" . $name);
+  if (!$env) {
+    return $default;
+  }
+  return $env;
+}
+
+// Get config from environment vars or leave as previously set above, if absent.
+$pwp_scriptname = fpwp_getenv("SCRIPTNAME", $pwp_scriptname);
 
 // Get the URL and split it, finding the target and the level...
 $pwp_req_uri = $_SERVER["REQUEST_URI"];


### PR DESCRIPTION
Didn't want to modify the config variables block to keep it the simplest possible. Priority was to keep the existing usability.
As of now, it's only meant for the only mandatory configuration. However, it is implemented as a function for further reuse, if desired.
Feature needed to provide an easy usage experience when adding Docker support later.