### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5-apache
+FROM php:7-apache
 
 COPY emailusers.php /var/www/html/
 ENV PWP_SCRIPTNAME emailusers.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM php:5-apache
+
+COPY emailusers.php /var/www/html/
+ENV PWP_SCRIPTNAME emailusers.php
+
+ADD http://www.mariovaldez.net/software/phpwpoison/files/pwpwords.tar.gz /var/www/html/
+RUN \
+  tar xvf pwpwords.tar.gz


### PR DESCRIPTION
Following setup instructions.
Just runs in a Apache/PHP 7.x server. Has an already configured ```PWP_SCRIPTNAME``` environment var default, which can be overriden (both on build and run time). Fetches and untars words file.

Test it by running my [Automated Build](https://docs.docker.com/docker-hub/builds/) from my source repo:
```
docker run --rm -it -p 8888:80 pataquets/phpwpoison
```
Browse to localhost:8888/emailusers.php